### PR TITLE
Align dashboard document cards in one row on desktop

### DIFF
--- a/frontend/src/styles/revolutionary-design.css
+++ b/frontend/src/styles/revolutionary-design.css
@@ -128,11 +128,11 @@
 /* ===== GRID DASHBOARD RESPONSIVE ===== */
 .dashboard-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(4, 1fr);
   grid-template-rows: auto auto;
-  grid-template-areas: 
-    "cv questionnaire offre"
-    "metier conseils conseils";
+  grid-template-areas:
+    "cv questionnaire offre metier"
+    "conseils conseils conseils conseils";
   gap: 2rem;
   margin-bottom: 2rem;
   align-items: start;


### PR DESCRIPTION
## Summary
- Display CV, questionnaire, job offer, and reconversion profession tiles on the same row for desktop dashboards

## Testing
- `CI=true npm test --silent` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b35bf771508323a006bd5e369bd135