### PR TITLE
Refine dashboard document card layout

### DIFF
--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -116,15 +116,12 @@ const DocumentCard = ({
       </div>
       <div className="revolutionary-service-content">
         <h4 className={`revolutionary-service-title ${uploaded ? '' : 'disabled'}`}>{title}</h4>
-        <p className={`revolutionary-service-description ${uploaded ? '' : 'disabled'}`}>{description}</p>
+        {description && (
+          <p className={`revolutionary-service-description ${uploaded ? '' : 'disabled'}`}>{description}</p>
+        )}
         {uploaded && fileName && (
           <div className="revolutionary-service-missing">
             <p className="revolutionary-service-missing-text">📄 {fileName}</p>
-          </div>
-        )}
-        {!uploaded && (
-          <div className="revolutionary-service-missing">
-            <p className="revolutionary-service-missing-text">À ajouter</p>
           </div>
         )}
         <div className="revolutionary-document-actions" style={{ marginTop: 12 }}>
@@ -548,7 +545,6 @@ const Dashboard = () => {
               <DocumentCard
                 type="cv"
                 title="Mon CV"
-                description="Document essentiel pour toutes les analyses IA"
                 icon={<FiFileText />}
                 color="#0a6b79"
                 uploaded={!!documentStatus.cv?.uploaded}
@@ -563,7 +559,6 @@ const Dashboard = () => {
               <DocumentCard
                 type="questionnaire"
                 title="Questionnaire personnel"
-                description="Vos objectifs et aspirations professionnelles"
                 icon={<FiUser />}
                 color="#f59e0b"
                 uploaded={!!documentStatus.questionnaire?.uploaded}
@@ -578,7 +573,6 @@ const Dashboard = () => {
               <DocumentCard
                 type="offre_emploi"
                 title="Offre d'emploi"
-                description="Pour l'analyse de compatibilité détaillée"
                 icon={<FiTarget />}
                 color="#22c55e"
                 uploaded={!!documentStatus.offre_emploi?.uploaded}
@@ -593,14 +587,13 @@ const Dashboard = () => {
               <DocumentCard
                 type="metier_souhaite"
                 title="Métier de reconversion"
-                description="Explorez un nouveau domaine professionnel"
                 icon={<FiRefreshCw />}
                 color="#8b5cf6"
                 uploaded={!!documentStatus.metier_souhaite?.uploaded}
                 fileName={documentStatus.metier_souhaite?.name}
-                onFileUpload={(e) => handleFileUpload(e, 'metier_souhaite')}
+                onFileUpload={undefined}
                 onTextClick={() => setShowTextModal('metier_souhaite')}
-                isTextOnly={false}
+                isTextOnly={true}
                 isUploading={loading}
               />
             </div>

--- a/frontend/src/styles/revolutionary-design.css
+++ b/frontend/src/styles/revolutionary-design.css
@@ -30,7 +30,7 @@
 /* Grille documents révolutionnaire pour le dashboard */
 .revolutionary-dashboard .revolutionary-document-types {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 20px;
   max-width: 1600px;
   margin: 0 auto 40px auto;
@@ -57,6 +57,7 @@
   background: #f0fdf4;
   border: 1px solid #bbf7d0;
   border-radius: 14px;
+  width: 100%;
   padding: 28px;
   color: #166534;
   box-shadow: var(--shadow-card);
@@ -113,7 +114,7 @@
 /* ===== RESPONSIVE PROPRE ===== */
 @media (max-width: 1400px) {
   .revolutionary-dashboard .revolutionary-document-types {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 16px;
   }
 }
@@ -128,11 +129,11 @@
 /* ===== GRID DASHBOARD RESPONSIVE ===== */
 .dashboard-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-template-rows: auto auto;
-  grid-template-areas: 
-    "cv questionnaire offre"
-    "metier conseils conseils";
+  grid-template-areas:
+    "cv questionnaire offre metier"
+    "conseils conseils conseils conseils";
   gap: 2rem;
   margin-bottom: 2rem;
   align-items: start;


### PR DESCRIPTION
## Summary
- Use `minmax(0,1fr)` columns and full-width tiles so dashboard document cards align evenly
- Remove helper descriptions and "À ajouter" placeholders from document tiles
- Make the reconversion profession tile text-only by dropping the upload button

## Testing
- `cd frontend && CI=true npm test --silent` *(fails: react-scripts not found after `npm install` 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b35bf771508323a006bd5e369bd135