### PR TITLE
fix: avoid restoring outdated cover letter

### DIFF
--- a/frontend/src/components/CoverLetter/CoverLetterGenerator.js
+++ b/frontend/src/components/CoverLetter/CoverLetterGenerator.js
@@ -18,7 +18,7 @@ import { coverLetterApi } from '../../services/coverLetterApi';
 import toast from 'react-hot-toast';
 
 const CoverLetterGenerator = () => {
-  const { documentStatus, messages = [] } = useApp();
+  const { documentStatus } = useApp();
   const [activeStep, setActiveStep] = useState('advice'); // 'advice' ou 'generate'
   const [loading, setLoading] = useState(false);
   const [advice, setAdvice] = useState(null);
@@ -95,7 +95,7 @@ const CoverLetterGenerator = () => {
 
   useEffect(() => {
     restoreData();
-  }, [messages]);
+  }, []);
 
   // Nettoyer les données locales quand un nouveau document est chargé
   useEffect(() => {
@@ -114,50 +114,7 @@ const CoverLetterGenerator = () => {
   }, []);
 
   const restoreData = () => {
-    // Chat history en priorité
-    if (messages && messages.length > 0) {
-      if (!advice) {
-        const lastAdvice = [...messages].reverse().find(msg => 
-          msg.role === 'assistant' && 
-          (msg.action_type === 'cover_letter_advice_response' || 
-           msg.content?.includes('Structure recommandée'))
-        );
-        if (lastAdvice) {
-          setAdvice(lastAdvice.content);
-          console.log('✅ Conseils restaurés depuis chat');
-          return;
-        }
-      }
-
-      if (!generatedLetter) {
-        const lastLetter = [...messages].reverse().find(msg => 
-          msg.role === 'assistant' && 
-          (// ✅ CHERCHER TOUS LES TYPES D'ACTION POUR LES LETTRES
-           msg.action_type === 'cover_letter_generated' ||
-           msg.action_type === 'cover_letter_response' ||
-           msg.action_type === 'cover_letter' ||
-           // ✅ OU DETECTER PAR LE CONTENU
-           (msg.content?.length > 300 && (
-             msg.content?.includes('Madame, Monsieur') ||
-             msg.content?.includes('Objet :') ||
-             msg.content?.includes('motivation') ||
-             msg.content?.includes('candidature') ||
-             msg.content?.includes('poste') ||
-             msg.content?.includes('emploi')
-           )))
-        );
-        if (lastLetter) {
-          setGeneratedLetter({
-            content: lastLetter.content,
-            metadata: lastLetter.metadata || {}
-          });
-          console.log('✅ Lettre restaurée depuis chat, action_type:', lastLetter.action_type);
-          return;
-        }
-      }
-    }
-
-    // Sinon localStorage
+    // Restaurer uniquement depuis localStorage pour éviter la persistance d'anciennes lettres
     if (!advice) {
       const stored = getFromLocalStorage('iamonjob_advice');
       if (stored) {


### PR DESCRIPTION
## Summary
- avoid restoring cover letter from chat history in generator
- rely on localStorage only when loading previous advice or letters

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b56861a42c8323bc41932a35ff2b05