### PR TITLE
Unify service endpoints and add skills analysis

### DIFF
--- a/backend/routes/generic_services.py
+++ b/backend/routes/generic_services.py
@@ -101,8 +101,17 @@ SERVICES_CONFIG = {
         "output_key": "email",
         "action_type": "followup_email_generated",
         "requires_cv": False,
-        "requires_job": True, 
+        "requires_job": True,
         "requires_questionnaire": False,
+        "allows_notes": True
+    },
+    "skills_analysis": {
+        "title": "Analyse des Compétences",
+        "output_key": "analysis",
+        "action_type": "skills_analysis_response",
+        "requires_cv": True,
+        "requires_job": False,
+        "requires_questionnaire": True,
         "allows_notes": True
     },
     "salary_negotiation": {

--- a/frontend/src/utils/localStorageUtils.js
+++ b/frontend/src/utils/localStorageUtils.js
@@ -17,7 +17,8 @@ const STORAGE_KEYS_TO_CLEAR = [
   'iamonjob_ats_optimization',
   'iamonjob_matching',
   'iamonjob_cover_advice',
-  'iamonjob_cover_generate',
+  'iamonjob_cover_generate', // ancienne clé (compatibilité)
+  'iamonjob_cover_letter',   // nouvelle clé pour les lettres générées
   'iamonjob_follow_up',
   'iamonjob_interview_prep',
   'iamonjob_pitch',

--- a/routes/services.py
+++ b/routes/services.py
@@ -1,396 +1,97 @@
 # routes/services.py
-"""
-Routes pour les services IA
-"""
+"""Routes pour les services IA"""
 
-from flask import Blueprint, request, jsonify, session
-from datetime import datetime
-import os
-from services.stateless_manager import StatelessDataManager
+from flask import Blueprint, request, jsonify
 from backend.routes.api.auth_api import verify_jwt_token
+from backend.routes.generic_services import handle_generic_service
 
 services_bp = Blueprint('services', __name__)
 
 @services_bp.route('/api/actions/cover-letter_generate', methods=['POST'])
+@verify_jwt_token
 def action_cover_letter_generate():
     """Action rapide: Générer une lettre de motivation"""
-    try:
-        data = request.get_json() or {}
-        user_notes = data.get('notes', '')
-        service_id = data.get('service_id', 'cover_letter_generate')
-        
-        # Utiliser StatelessDataManager pour la cohérence
-        user_data = StatelessDataManager.get_user_data()
-        documents = user_data.get('documents', {})
-        
-        print(f"🔍 === DEBUG {service_id.upper()} ===")
-        print(f"Documents disponibles: {list(documents.keys())}")
-        
-        # Récupérer tous les documents
-        cv_data = documents.get('cv', {})
-        job_data = documents.get('offre_emploi', {})
-        questionnaire_data = documents.get('questionnaire', {})
-        
-        print(f"CV uploaded: {cv_data.get('uploaded', False)}")
-        print(f"Job uploaded: {job_data.get('uploaded', False)}")
-        print(f"Questionnaire uploaded: {questionnaire_data.get('uploaded', False)}")
-        
-        # Vérifier les documents obligatoires
-        if not cv_data.get('uploaded') or not job_data.get('uploaded'):
-            return jsonify({
-                "success": False,
-                "error": "CV et offre d'emploi requis pour générer une lettre de motivation"
-            }), 400
-        
-        # Extraire le contenu
-        cv_content = cv_data.get('content', '')
-        job_content = job_data.get('content', '')
-        questionnaire_content = questionnaire_data.get('content', '') if questionnaire_data.get('uploaded') else ''
-        
-        print(f"CV content length: {len(cv_content)}")
-        print(f"Job content length: {len(job_content)}")
-        print(f"Questionnaire content length: {len(questionnaire_content)}")
-        print(f"User notes: {user_notes}")
-        
-        # Utiliser execute_ai_service
-        try:
-            from services.ai_service_prompts import execute_ai_service
-            
-            print("🤖 Génération de lettre de motivation avec IA...")
-            
-            # Appeler execute_ai_service avec le bon service_id
-            cover_letter = execute_ai_service(
-                service_id='cover_letter_generate',
-                cv_content=cv_content,
-                job_content=job_content, 
-                questionnaire_content=questionnaire_content,
-                user_notes=user_notes
-            )
-            
-            print(f"✅ Lettre générée: {len(cover_letter)} caractères")
-            
-        except ImportError as e:
-            print(f"❌ Erreur import execute_ai_service: {e}")
-            # Fallback si execute_ai_service n'est pas disponible
-            cover_letter = f"Erreur : Service IA temporairement indisponible. {str(e)}"
-        
-        # Sauvegarder dans l'historique
-        user_message = {
-            "role": "user",
-            "content": f"🚀 Service : {service_id}",
-            "timestamp": datetime.now().isoformat(),
-            "action_type": service_id
-        }
-        
-        ai_message = {
-            "role": "assistant", 
-            "content": cover_letter,
-            "timestamp": datetime.now().isoformat(),
-            "action_type": f"{service_id}_response"
-        }
-        
-        # Ajouter à l'historique
-        if 'chat_history' not in user_data:
-            user_data['chat_history'] = []
-        
-        user_data['chat_history'].extend([user_message, ai_message])
-        
-        # Sauvegarder les données utilisateur
-        StatelessDataManager.save_user_data(user_data)
-        
-        return jsonify({
-            "success": True,
-            "message": "Lettre de motivation générée avec succès",
-            "analysis": cover_letter
-        }), 200
-        
-    except Exception as e:
-        print(f"❌ Erreur génération lettre: {e}")
-        return jsonify({
-            "success": False,
-            "error": f"Erreur lors de la génération: {str(e)}"
-        }), 500
+    return handle_generic_service('cover_letter_generate', request)
 
 @services_bp.route('/api/cover-letter/advice', methods=['POST'])
+@verify_jwt_token
 def cover_letter_advice():
     """Conseils pour lettre de motivation"""
-    try:
-        data = request.get_json() or {}
-        user_notes = data.get('notes', '')
-        service_id = data.get('service_id', 'cover_letter_advice')
-        
-        # Utiliser StatelessDataManager pour la cohérence
-        user_data = StatelessDataManager.get_user_data()
-        documents = user_data.get('documents', {})
-        
-        print(f"🔍 === DEBUG {service_id.upper()} ===")
-        print(f"Documents disponibles: {list(documents.keys())}")
-        
-        # Récupérer tous les documents
-        cv_data = documents.get('cv', {})
-        job_data = documents.get('offre_emploi', {})
-        questionnaire_data = documents.get('questionnaire', {})
-        
-        # Vérifier qu'au moins un document est disponible
-        # Accepte les documents existants même si 'uploaded' est False
-        if not cv_data and not job_data:
-            return jsonify({
-                "success": False,
-                "error": "CV ou offre d'emploi requis pour générer des conseils"
-            }), 400
-        
-        # Extraire le contenu
-        cv_content = cv_data.get('content', '')
-        job_content = job_data.get('content', '')
-        questionnaire_content = questionnaire_data.get('content', '') if questionnaire_data.get('uploaded') else ''
-        
-        # Utiliser execute_ai_service
-        try:
-            from services.ai_service_prompts import execute_ai_service
-            
-            print("🤖 Génération de conseils lettre de motivation avec IA...")
-            
-            # Appeler execute_ai_service avec le bon service_id
-            advice = execute_ai_service(
-                service_id='cover_letter_advice',
-                cv_content=cv_content,
-                job_content=job_content, 
-                questionnaire_content=questionnaire_content,
-                user_notes=user_notes
-            )
-            
-            print(f"✅ Conseils générés: {len(advice)} caractères")
-            
-        except ImportError as e:
-            print(f"❌ Erreur import execute_ai_service: {e}")
-            # Fallback si execute_ai_service n'est pas disponible
-            advice = f"Erreur : Service IA temporairement indisponible. {str(e)}"
-        
-        # Sauvegarder dans l'historique
-        user_message = {
-            "role": "user",
-            "content": f"🚀 Service : {service_id}",
-            "timestamp": datetime.now().isoformat(),
-            "action_type": service_id
-        }
-        
-        ai_message = {
-            "role": "assistant", 
-            "content": advice,
-            "timestamp": datetime.now().isoformat(),
-            "action_type": f"{service_id}_response"
-        }
-        
-        # Ajouter à l'historique
-        if 'chat_history' not in user_data:
-            user_data['chat_history'] = []
-        
-        user_data['chat_history'].extend([user_message, ai_message])
-        
-        # Sauvegarder les données utilisateur
-        StatelessDataManager.save_user_data(user_data)
-        
-        return jsonify({
-            "success": True,
-            "message": "Conseils lettre de motivation générés avec succès",
-            "analysis": advice
-        }), 200
-        
-    except Exception as e:
-        print(f"❌ Erreur génération conseils: {e}")
-        return jsonify({
-            "success": False,
-            "error": f"Erreur lors de la génération des conseils: {str(e)}"
-        }), 500
+    return handle_generic_service('cover_letter_advice', request)
 
 @services_bp.route('/api/cover-letter/generate', methods=['POST'])
+@verify_jwt_token
 def cover_letter_generate():
     """Génération lettre de motivation (endpoint alternatif)"""
-    return action_cover_letter_generate()
+    return handle_generic_service('cover_letter_generate', request)
 
 @services_bp.route('/api/interview/prepare', methods=['POST'])
 @verify_jwt_token
 def interview_prepare():
     """Préparation entretien"""
-    return handle_service_request('interview_prep')
+    return handle_generic_service('interview_prep', request)
 
 @services_bp.route('/api/pitch/generate', methods=['POST'])
 @verify_jwt_token
 def pitch_generate():
     """Génération pitch professionnel"""
-    return handle_service_request('professional_pitch')
+    return handle_generic_service('professional_pitch', request)
 
 @services_bp.route('/api/presentation/generate', methods=['POST'])
 @verify_jwt_token
 def presentation_generate():
     """Génération slides présentation"""
-    return handle_service_request('presentation_slides')
+    return handle_generic_service('presentation_slides', request)
 
 @services_bp.route('/api/reconversion/analyze', methods=['POST'])
 @verify_jwt_token
 def reconversion_analyze():
     """Analyse reconversion"""
-    return handle_service_request('reconversion_analysis')
+    return handle_generic_service('reconversion_analysis', request)
 
 @services_bp.route('/api/career/orientation', methods=['POST'])
 @verify_jwt_token
 def career_orientation():
     """Orientation métier"""
-    return handle_service_request('career_transition')
+    return handle_generic_service('career_transition', request)
 
 @services_bp.route('/api/industry/orientation', methods=['POST'])
 @verify_jwt_token
 def industry_orientation():
     """Orientation industrie"""
-    return handle_service_request('industry_orientation')
+    return handle_generic_service('industry_orientation', request)
 
 @services_bp.route('/api/followup/generate', methods=['POST'])
 @verify_jwt_token
 def followup_generate():
     """Génération email de relance"""
-    return handle_service_request('follow_up_email')
+    return handle_generic_service('follow_up_email', request)
 
 @services_bp.route('/api/salary/prepare', methods=['POST'])
 @verify_jwt_token
 def salary_prepare():
     """Préparation négociation salaire"""
-    return handle_service_request('salary_negotiation')
+    return handle_generic_service('salary_negotiation', request)
 
-def handle_service_request(service_id):
-    """Fonction générique pour gérer les requêtes de service"""
-    try:
-        data = request.get_json() or {}
-        user_notes = data.get('notes', '')
-        
-        # ✅ CORRIGÉ : Utiliser l'utilisateur connecté pour l'individualisation
-        # Maintenant que toutes les routes ont @verify_jwt_token, on a accès à request.current_user
-        user_email = request.current_user.email
-        print(f"👤 Individualisation: Service {service_id} pour {user_email}")
-        
-        # Utiliser StatelessDataManager avec individualisation
-        user_data = StatelessDataManager.get_user_data_by_email(user_email)
-        
-        documents = user_data.get('documents', {})
-        
-        print(f"🔍 === DEBUG {service_id.upper()} ===")
-        print(f"Documents disponibles: {list(documents.keys())}")
-        print(f"Documents détaillés: {documents}")
-        
-        # Récupérer tous les documents
-        cv_data = documents.get('cv', {})
-        job_data = documents.get('offre_emploi', {})
-        questionnaire_data = documents.get('questionnaire', {})
-        
-        # Vérifier les documents obligatoires (selon le service)
-        if service_id in ['presentation_slides', 'reconversion_analysis', 'follow_up_email', 'salary_negotiation']:
-            if not cv_data.get('uploaded'):
-                return jsonify({
-                    "success": False,
-                    "error": f"CV requis pour {service_id}"
-                }), 400
-        elif service_id in ['interview_prep']:
-            if not cv_data.get('uploaded') or not job_data.get('uploaded'):
-                return jsonify({
-                    "success": False,
-                    "error": "CV et offre d'emploi requis pour préparer l'entretien"
-                }), 400
-        elif service_id in ['professional_pitch']:
-            if not cv_data.get('uploaded'):
-                return jsonify({
-                    "success": False,
-                    "error": "CV requis pour générer un pitch professionnel"
-                }), 400
-        
-        # Extraire le contenu
-        cv_content = cv_data.get('content', '')
-        job_content = job_data.get('content', '')
-        questionnaire_content = questionnaire_data.get('content', '') if questionnaire_data.get('uploaded') else ''
-        
-        # Utiliser execute_ai_service
-        try:
-            from services.ai_service_prompts import execute_ai_service
-            
-            print(f"🤖 Génération {service_id} avec IA...")
-            
-            # Appeler execute_ai_service avec le bon service_id
-            result = execute_ai_service(
-                service_id=service_id,
-                cv_content=cv_content,
-                job_content=job_content, 
-                questionnaire_content=questionnaire_content,
-                user_notes=user_notes
-            )
-            
-            print(f"✅ {service_id} généré: {len(result)} caractères")
-            
-        except ImportError as e:
-            print(f"❌ Erreur import execute_ai_service: {e}")
-            # Fallback si execute_ai_service n'est pas disponible
-            result = f"Erreur : Service IA temporairement indisponible. {str(e)}"
-        
-        # Sauvegarder dans l'historique
-        user_message = {
-            "role": "user",
-            "content": f"🚀 Service : {service_id}",
-            "timestamp": datetime.now().isoformat(),
-            "action_type": service_id
-        }
-        
-        ai_message = {
-            "role": "assistant", 
-            "content": result,
-            "timestamp": datetime.now().isoformat(),
-            "action_type": f"{service_id}_response"
-        }
-        
-        # Ajouter à l'historique
-        if 'chat_history' not in user_data:
-            user_data['chat_history'] = []
-        
-        user_data['chat_history'].extend([user_message, ai_message])
-        
-        # Sauvegarder les données utilisateur
-        StatelessDataManager.save_user_data(user_data)
-        
-        return jsonify({
-            "success": True,
-            "message": f"{service_id} généré avec succès",
-            "analysis": result
-        }), 200
-        
-    except Exception as e:
-        print(f"❌ Erreur génération {service_id}: {e}")
-        return jsonify({
-            "success": False,
-            "error": f"Erreur lors de la génération: {str(e)}"
-        }), 500
+@services_bp.route('/api/skills/analyze', methods=['POST'])
+@verify_jwt_token
+def skills_analyze():
+    """Analyse des compétences"""
+    return handle_generic_service('skills_analysis', request)
 
 @services_bp.route('/api/actions/compatibility', methods=['POST'])
 def matching_cv_offre_analysis():
     """Route pour l'analyse de compatibilité (utilise le système générique)"""
     try:
-        from backend.routes.generic_services import handle_generic_service
-        
-        # Récupérer le service_id depuis la requête
         data = request.get_json() or {}
         service_id = data.get('service_id', 'matching_cv_offre')
-        
         print(f"🎯 Route compatibility appelée avec service_id: {service_id}")
-        
-        # Utiliser le handler générique
         return handle_generic_service(service_id, request)
-        
-    except ImportError as e:
-        print(f"❌ Erreur import generic_services: {e}")
-        return jsonify({
-            "success": False,
-            "error": "Service temporairement indisponible"
-        }), 503
     except Exception as e:
         print(f"❌ Erreur route compatibility: {e}")
         return jsonify({
             "success": False,
-            "error": f"Erreur lors de l'analyse de compatibilité: {str(e)}"
+            "error": f"Erreur lors de l'analyse de compatibilité: {str(e)}",
         }), 500
 
 @services_bp.route('/api/services/config', methods=['GET'])
@@ -398,13 +99,12 @@ def get_services_config():
     """Endpoint public pour récupérer la configuration des services"""
     try:
         from backend.admin.services_manager import services_manager
-        
+
         return jsonify({
             "success": True,
             "themes": services_manager.get_services_by_theme(),
             "featured": services_manager.get_featured_service()
         })
-        
     except ImportError as e:
         print(f"❌ Erreur import services_manager: {e}")
         # Fallback avec configuration locale
@@ -504,18 +204,15 @@ def get_services_config():
             },
             "featured": None
         })
-        
     except Exception as e:
         print(f"❌ Erreur endpoint services config: {e}")
         return jsonify({
             "success": False,
-            "error": "Erreur lors de la récupération de la configuration des services"
+            "error": "Erreur lors de la récupération de la configuration des services",
         }), 500
+
 
 def register_services_routes(app):
     """Enregistre les routes de services dans l'application Flask"""
     app.register_blueprint(services_bp)
-    
-    # === ROUTES MANQUANTES ===
-    # Note: Les routes des services IA sont gérées par generic_services.py
-    # Pas besoin de les redéfinir ici pour éviter les conflits 
+    # Les routes IA sont gérées par generic_services.py


### PR DESCRIPTION
## Summary
- Delegate cover letter, interview, follow-up email and other routes to the generic service handler
- Add `skills_analysis` service configuration and route
- Clear outdated cover letters from local storage when new documents are uploaded

## Testing
- `python -m py_compile routes/services.py backend/routes/generic_services.py services/stateless_manager.py`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b59a1f611c8323a783d5b47ea40bdb