### PR TITLE
fix: render markdown tables in chat messages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "react-icons": "^4.7.1",
     "react-scripts": "5.0.1",
     "react-dropzone": "^14.2.3",
-    "react-markdown": "^9.0.1"
+    "react-markdown": "^9.0.1",
+    "remark-gfm": "^3.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/Chat/MessageList.js
+++ b/frontend/src/components/Chat/MessageList.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { FiUser, FiBot, FiCopy, FiClock } from 'react-icons/fi';
 import './MessageList.css';
 import '../Common/SimpleMarkdownRenderer.css';
@@ -48,6 +49,7 @@ const MessageList = ({ messages }) => {
       return (
         <div className="markdown-content">
           <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
             components={{
               table: ({ children }) => (
                 <div className="table-wrapper">

--- a/frontend/src/components/Common/SimpleMarkdownRenderer.js
+++ b/frontend/src/components/Common/SimpleMarkdownRenderer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import './SimpleMarkdownRenderer.css';
 
 const SimpleMarkdownRenderer = ({ content, serviceType = 'default' }) => {
@@ -16,6 +17,7 @@ const SimpleMarkdownRenderer = ({ content, serviceType = 'default' }) => {
     return (
       <div className={`markdown-renderer ${serviceType}`}>
         <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
           components={{
             table: ({ children }) => (
               <div className="table-wrapper">


### PR DESCRIPTION
## Summary
- add remark-gfm dependency for GitHub-flavored markdown
- enable table rendering in SimpleMarkdownRenderer and MessageList via ReactMarkdown GFM plugin

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/remark-gfm)*
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bada27745083239a918088c297a9cb