### PR TITLE
Fix dynamic service page loading

### DIFF
--- a/frontend/src/components/Common/GenericDocumentProcessor.js
+++ b/frontend/src/components/Common/GenericDocumentProcessor.js
@@ -74,19 +74,54 @@ const GenericDocumentProcessor = ({ serviceConfig: propServiceConfig }) => {
 
   // Récupérer la configuration du service depuis l'URL
   useEffect(() => {
-    if (propServiceConfig) {
-      // Si la config est passée en prop (ancien usage)
-      setServiceConfig(propServiceConfig);
-    } else if (serviceId) {
-      // Si on récupère depuis l'URL
-      const mappedServiceId = URL_TO_SERVICE_MAPPING[serviceId] || serviceId;
-      const config = getServiceConfig(mappedServiceId);
-      if (config) {
-        setServiceConfig(config);
-      } else {
+    const loadConfig = async () => {
+      if (propServiceConfig) {
+        // Si la config est passée en prop (ancien usage)
+        setServiceConfig(propServiceConfig);
+        return;
+      }
+
+      if (!serviceId) return;
+
+      // Utiliser le mapping ou convertir les tirets en underscores
+      const mappedServiceId =
+        URL_TO_SERVICE_MAPPING[serviceId] || serviceId.replace(/-/g, '_');
+
+      // D'abord, essayer de récupérer la configuration locale
+      const localConfig = getServiceConfig(mappedServiceId);
+      if (localConfig) {
+        setServiceConfig(localConfig);
+        return;
+      }
+
+      // Sinon, tenter de charger depuis l'API (Supabase)
+      try {
+        const response = await fetch(`/api/services/${mappedServiceId}`);
+        const data = await response.json();
+
+        if (response.ok && data.success && data.service) {
+          const apiConfig = {
+            id: mappedServiceId,
+            title: data.service.title,
+            coachAdvice: data.service.coach_advice,
+            requiresCV: data.service.requires_cv,
+            requiresJobOffer: data.service.requires_job_offer,
+            requiresQuestionnaire: data.service.requires_questionnaire,
+            allowsNotes: data.service.allows_notes || false,
+            apiEndpoint: `/api/services/execute/${mappedServiceId}`,
+            storageKey: `iamonjob_${mappedServiceId}`
+          };
+          setServiceConfig(apiConfig);
+        } else {
+          setError(`Service "${serviceId}" non trouvé`);
+        }
+      } catch (err) {
+        console.error('Erreur chargement service:', err);
         setError(`Service "${serviceId}" non trouvé`);
       }
-    }
+    };
+
+    loadConfig();
   }, [serviceId, propServiceConfig]);
 
   // Charger un résultat déjà sauvegardé le cas échéant


### PR DESCRIPTION
## Summary
- load service configuration from API when not found locally
- allow hyphenated slugs by converting to underscore IDs

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc2254e6f08323ac2ce962003f31ba