### PR TITLE
fix: load coach advice from supabase

### DIFF
--- a/frontend/src/components/Common/GenericDocumentProcessor.js
+++ b/frontend/src/components/Common/GenericDocumentProcessor.js
@@ -88,68 +88,82 @@ const GenericDocumentProcessor = ({ serviceConfig: propServiceConfig }) => {
       const mappedServiceId =
         URL_TO_SERVICE_MAPPING[serviceId] || serviceId.replace(/-/g, '_');
 
-      // D'abord, essayer de récupérer la configuration locale
-      const localConfig = getServiceConfig(mappedServiceId);
-      if (localConfig) {
-        // Appliquer le même système de fallback pour les configs locales
-        const enhancedConfig = {
-          ...localConfig,
-          coachAdvice: localConfig.coachAdvice || ''
-        };
-        setServiceConfig(enhancedConfig);
-        return;
-      }
+      // Récupérer la configuration locale (fallback)
+      const localConfig = getServiceConfig(mappedServiceId) || {};
 
-      // Sinon, tenter de charger depuis l'API (Supabase)
+      // Toujours tenter de charger la configuration depuis l'API pour récupérer
+      // les dernières modifications depuis Supabase
       try {
-        // Certains services peuvent être enregistrés avec des tirets dans Supabase
         const apiServiceId = mappedServiceId.replace(/_/g, '-');
-
-        // Ajouter un timestamp pour éviter le cache
         const timestamp = Date.now();
         let response = await fetch(`/api/services/${apiServiceId}?t=${timestamp}`);
         let data = await response.json();
-
-        // Si aucune configuration trouvée, essayer la version originale
         if (!(response.ok && data.success && data.service)) {
           response = await fetch(`/api/services/${mappedServiceId}?t=${timestamp}`);
           data = await response.json();
         }
-
         if (response.ok && data.success && data.service) {
           const serviceApiId = data.service.id || apiServiceId;
           const clientId = serviceApiId.replace(/-/g, '_');
-          
           console.log('🔍 GenericDocumentProcessor - Service reçu:', {
             id: serviceApiId,
             title: data.service.title,
             coach_advice: data.service.coach_advice
           });
-          
-          // Charger les conseils du coach depuis Supabase uniquement
-          
-          const apiConfig = {
+          const finalConfig = {
+            ...localConfig,
             id: clientId,
             apiId: serviceApiId,
-
-            title: data.service.title,
-            coachAdvice: data.service.coach_advice || '', // Conseils du coach (Supabase uniquement)
-            requiresCV: data.service.requires_cv,
-            requiresJobOffer: data.service.requires_job_offer,
-            requiresQuestionnaire: data.service.requires_questionnaire,
-            allowsNotes: data.service.allows_notes || false,
-            apiEndpoint: `/api/services/execute/${serviceApiId}`,
-            storageKey: `iamonjob_${clientId}`
-
+            title: data.service.title || localConfig.title || '',
+            coachAdvice:
+              data.service.coach_advice || localConfig.coachAdvice || '',
+            requiresCV:
+              data.service.requires_cv ?? localConfig.requiresCV ?? false,
+            requiresJobOffer:
+              data.service.requires_job_offer ?? localConfig.requiresJobOffer ?? false,
+            requiresQuestionnaire:
+              data.service.requires_questionnaire ?? localConfig.requiresQuestionnaire ?? false,
+            allowsNotes:
+              data.service.allows_notes ?? localConfig.allowsNotes ?? false,
+            apiEndpoint:
+              localConfig.apiEndpoint || `/api/services/execute/${serviceApiId}`,
+            storageKey: localConfig.storageKey || `iamonjob_${clientId}`
           };
-          console.log('🔍 GenericDocumentProcessor - Config finale:', apiConfig);
-          setServiceConfig(apiConfig);
+          console.log('🔍 GenericDocumentProcessor - Config finale:', finalConfig);
+          setServiceConfig(finalConfig);
+          return;
+        }
+        if (Object.keys(localConfig).length > 0) {
+          const fallbackConfig = {
+            ...localConfig,
+            id: mappedServiceId,
+            apiId: apiServiceId,
+            coachAdvice: localConfig.coachAdvice || '',
+            apiEndpoint:
+              localConfig.apiEndpoint || `/api/services/execute/${apiServiceId}`,
+            storageKey: localConfig.storageKey || `iamonjob_${mappedServiceId}`
+          };
+          setServiceConfig(fallbackConfig);
         } else {
           setError(`Service "${serviceId}" non trouvé`);
         }
       } catch (err) {
         console.error('Erreur chargement service:', err);
-        setError(`Service "${serviceId}" non trouvé`);
+        if (Object.keys(localConfig).length > 0) {
+          const fallbackConfig = {
+            ...localConfig,
+            id: mappedServiceId,
+            apiId: mappedServiceId.replace(/_/g, '-'),
+            coachAdvice: localConfig.coachAdvice || '',
+            apiEndpoint:
+              localConfig.apiEndpoint ||
+              `/api/services/execute/${mappedServiceId.replace(/_/g, '-')}`,
+            storageKey: localConfig.storageKey || `iamonjob_${mappedServiceId}`
+          };
+          setServiceConfig(fallbackConfig);
+        } else {
+          setError(`Service "${serviceId}" non trouvé`);
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
- ensure GenericDocumentProcessor merges Supabase coach advice with local config while preserving API endpoints

## Testing
- `cd frontend && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bfb9cebb9c8323bb22c5555fffb755