### PR TITLE
feat: export AI analyses as HTML files

### DIFF
--- a/frontend/src/components/Common/GenericDocumentProcessor.js
+++ b/frontend/src/components/Common/GenericDocumentProcessor.js
@@ -285,18 +285,75 @@ const GenericDocumentProcessor = ({ serviceConfig: propServiceConfig }) => {
     }
   };
 
-  const downloadAsText = () => {
+  const escapeHtml = (text) =>
+    text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+
+  const buildHtmlDocument = (title, content) => `<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>${escapeHtml(title)}</title>
+    <style>
+      body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        background: #f8fafc;
+        color: #0f172a;
+        margin: 0;
+        padding: 2.5rem;
+        line-height: 1.7;
+      }
+      .container {
+        background: #ffffff;
+        border-radius: 16px;
+        padding: 2rem;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+        border: 1px solid #e2e8f0;
+      }
+      h1 {
+        margin-top: 0;
+        font-size: 1.75rem;
+        color: #0a6b79;
+      }
+      .timestamp {
+        font-size: 0.9rem;
+        color: #64748b;
+        margin-bottom: 1.5rem;
+      }
+      .content {
+        font-size: 1rem;
+        color: #1f2937;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>${escapeHtml(title)}</h1>
+      <div class="timestamp">Export généré le ${new Date().toLocaleString('fr-FR')}</div>
+      <div class="content">${content}</div>
+    </div>
+  </body>
+</html>`;
+
+  const downloadAsHtml = () => {
     if (result) {
-      const blob = new Blob([result], { type: 'text/plain' });
+      const formattedResult = escapeHtml(result).replace(/\n/g, '<br />');
+      const documentTitle = serviceConfig?.name || 'Analyse IA';
+      const html = buildHtmlDocument(documentTitle, formattedResult);
+      const blob = new Blob([html], { type: 'text/html' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `${serviceConfig.id}_resultat.txt`;
+      a.download = `${serviceConfig.id}_resultat.html`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
-      toast.success('Téléchargement terminé !');
+      toast.success('Fichier HTML téléchargé !');
     }
   };
 
@@ -676,11 +733,11 @@ const GenericDocumentProcessor = ({ serviceConfig: propServiceConfig }) => {
                 Copier
               </button>
               <button
-                onClick={downloadAsText}
-                style={{ 
-                  display: 'flex', 
-                  alignItems: 'center', 
-                  gap: '0.5rem', 
+                onClick={downloadAsHtml}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.5rem',
                   padding: '0.75rem 1.5rem', 
                   fontSize: '1rem', 
                   fontWeight: '500', 
@@ -693,7 +750,7 @@ const GenericDocumentProcessor = ({ serviceConfig: propServiceConfig }) => {
                 }}
               >
                 <FiDownload />
-                Télécharger
+                Télécharger en HTML
               </button>
             </div>
             

--- a/frontend/src/components/CoverLetter/CoverLetterGenerator.js
+++ b/frontend/src/components/CoverLetter/CoverLetterGenerator.js
@@ -198,16 +198,71 @@ const CoverLetterGenerator = () => {
     });
   };
 
-  // Fonction pour télécharger en tant que fichier texte
-  const downloadAsText = (content, filename) => {
+  const escapeHtml = (text) =>
+    text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+
+  const buildHtmlDocument = (title, content) => `<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>${escapeHtml(title)}</title>
+    <style>
+      body {
+        font-family: 'Georgia', 'Times New Roman', serif;
+        background: #f9fafb;
+        color: #1f2937;
+        margin: 0;
+        padding: 2.5rem;
+        line-height: 1.8;
+      }
+      .container {
+        background: #ffffff;
+        border-radius: 12px;
+        padding: 2rem;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+        border: 1px solid #e5e7eb;
+      }
+      h1 {
+        margin-top: 0;
+        color: #0a6b79;
+        font-size: 2rem;
+      }
+      .timestamp {
+        font-size: 0.95rem;
+        color: #6b7280;
+        margin-bottom: 1.5rem;
+      }
+      .content {
+        font-size: 1.05rem;
+        white-space: normal;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>${escapeHtml(title)}</h1>
+      <div class="timestamp">Lettre générée le ${new Date().toLocaleString('fr-FR')}</div>
+      <div class="content">${content}</div>
+    </div>
+  </body>
+</html>`;
+
+  const downloadAsHtml = (content, filename, title = 'Lettre de motivation') => {
+    const formattedContent = escapeHtml(content).replace(/\n/g, '<br />');
+    const html = buildHtmlDocument(title, formattedContent);
     const element = document.createElement('a');
-    const file = new Blob([content], { type: 'text/plain' });
+    const file = new Blob([html], { type: 'text/html' });
     element.href = URL.createObjectURL(file);
-    element.download = filename;
+    element.download = filename.replace(/\.txt$/, '.html');
     document.body.appendChild(element);
     element.click();
     document.body.removeChild(element);
-    toast.success('Fichier téléchargé !');
+    toast.success('Lettre exportée en HTML !');
   };
 
   // Formatage du texte markdown simple
@@ -506,7 +561,7 @@ const CoverLetterGenerator = () => {
                     Copier
                   </button>
                   <button
-                    onClick={() => downloadAsText(generatedLetter.content, 'lettre_motivation.txt')}
+                    onClick={() => downloadAsHtml(generatedLetter.content, 'lettre_motivation.html')}
                     style={{
                       display: 'flex',
                       alignItems: 'center',
@@ -521,7 +576,7 @@ const CoverLetterGenerator = () => {
                     }}
                   >
                     <FiDownload />
-                    Télécharger
+                    Télécharger en HTML
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- replace the plain text download with a styled HTML export for AI analysis results
- add HTML export support for generated cover letters with basic formatting
- update download button labels to reflect the new HTML export format

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d540d7f8e8832388d8fed2e282ed02