### PR TITLE
Remove dashboard CTA for authenticated users on home page

### DIFF
--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -65,11 +65,7 @@ const Home = () => {
               Analysez votre CV, évaluez les offres, préparez vos entretiens... et décrochez le poste idéal.
             </p>
             <div className="hero-actions">
-              {isAuthenticated ? (
-                <Link to="/dashboard" className="btn btn-primary btn-lg">
-                  Accéder au tableau de bord
-                </Link>
-              ) : (
+              {!isAuthenticated && (
                 <>
                   <Link to="/register" className="btn btn-primary btn-lg">
                     Commencer gratuitement


### PR DESCRIPTION
## Summary
- update the Home hero actions so authenticated users no longer see the dashboard access button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d648eb9940832382145a73aaac9319